### PR TITLE
link to 2i2c and MD conduct/community guidelines

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -3,6 +3,6 @@
 As a joint-project between 2i2c and MetaDocencia, ScienceCore:climaterisk is subject to both of the following policies:
 
 - [2i2c Code of Conduct](https://compass.2i2c.org/code-of-conduct)
-- [MetaDocencia Community Guidelines](https://www.metadocencia.org/en/pdc)
+- [Pautas de Convivencia de MetaDocencia](https://www.metadocencia.org/pdc)
 
 The reporting procedure of either policy may be followed.

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,44 +1,8 @@
-
 # Code of Conduct
 
-## Our Pledge
+As a joint-project between 2i2c and MetaDocencia, ScienceCore:climaterisk is subject to both of the following policies:
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+- [2i2c Code of Conduct](https://compass.2i2c.org/code-of-conduct)
+- [MetaDocencia Community Guidelines](https://www.metadocencia.org/en/pdc)
 
-## Our Standards
-
-Examples of behavior that contributes to creating a positive environment include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-
-## Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant, version 1.4](http://contributor-covenant.org/version/1/4).
+The reporting procedure of either policy may be followed.


### PR DESCRIPTION
Clarify that ScienceCore:climaterisk should be consistent with both the 2i2c Code of Conduct and MetaDocencia Community Guidelines.  
