### PR TITLE
Remove manual trigger and PR comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - environment.yml
-  workflow_dispatch:
 
 jobs:
   build-and-push:
@@ -43,18 +42,3 @@ jobs:
     # Lets us monitor disks getting full as images get bigger over time
     - name: Show how much disk space is left
       run: df -h
-      
-    - name: Add PR comment with image tag
-      uses: actions/github-script@v7
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}        
-        script: |
-          var IMAGE_SHA_NAME = process.env.IMAGE_SHA_NAME;
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'Quay.io image tag 👉 [${IMAGE_SHA_NAME}](https://${IMAGE_SHA_NAME})'
-          })
-      env:
-        IMAGE_SHA_NAME: ${{ steps.build-push.outputs.IMAGE_SHA_NAME }}


### PR DESCRIPTION
Adding a comment to the PR is too complicated since it requires passing variables between different workflow runs.