### PR TITLE
Update Crowdin config and relative file references in translations

### DIFF
--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -39,3 +39,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
+
+      - name: Update relative file references in translations
+        run: |
+          find ./book/espanol -type f -name "*.md" -print0 | xargs -0 sed -i '' -e 's#assets#../assets#'
+          

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -15,9 +15,16 @@ preserve_hierarchy: true
 # Files configuration
 #
 files:
-  - source: /*.md
+  - source: CONDUCT.md
     dest: /%original_file_name%
-    translation: /%locale%/%original_file_name%
+    translation: /%original_file_name%.es
+  - source: CONTRIBUTING.md
+    dest: /%original_file_name%
+    translation: %original_file_name%.es
+  - source: README.md
+    dest: /%original_file_name%
+    translation: %original_file_name%.es
   - source: /book/**/*.md
     dest: /book/**/%original_file_name%
-    translation: /book/%locale%/**/%original_file_name%
+    translation: /book/espanol/**/%original_file_name%
+    ignore: /book/espanol/*.md


### PR DESCRIPTION
Make crowdin configs more explicit and account for nested file structure of translations when referring to `../../assets`.