### PR TITLE
fix: allow startup command to fail, remove `x` opt

### DIFF
--- a/start
+++ b/start
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
-jupyter nbconvert --execute --inplace climaterisk/book/Startup.ipynb
+# Allow this specific command to fail
+jupyter nbconvert --execute --inplace climaterisk/book/Startup.ipynb || true
 
 exec "$@"


### PR DESCRIPTION
Following @dhavide's encounter with a failed startup, this PR prevents failure in the startup executor from blocking the pod startup.

It also turns off `-x`.